### PR TITLE
Restructure toc

### DIFF
--- a/pathways/landing_page.py
+++ b/pathways/landing_page.py
@@ -60,8 +60,7 @@ class LandingPage:
                     curated_links.append(get_links_of_section(section["sections"]))
             return curated_links
 
-        book = toc["parts"][0]
-        chapters = book["chapters"]
+        chapters = toc["chapters"]
         self.curated_links = get_links_of_section(chapters)
 
     def get_title_from_text(self, markdown_text):

--- a/tests/test_files/test_landing/toc_whitelist.json
+++ b/tests/test_files/test_landing/toc_whitelist.json
@@ -1,25 +1,21 @@
 {
-  "parts": [
-      {
-          "chapters": [
-              {
-                  "file": "communication/communication",
-                  "sections": [
-                      {
-                          "file": "communication/comms-overview",
-                          "sections": [
-                              {
-                                  "file": "communication/comms-overview/comms-overview-principles",
-                                  "title": "Principles of Communicating with Wider Audiences"
-                              }
-                          ],
-                          "title": "Overview of Guide for Communication"
-                      }
-                  ]
-              }
-          ]
-      }
-  ],
-  "format": "jb-book",
-  "root": "welcome"
+    "chapters": [
+        {
+            "file": "communication/communication",
+            "sections": [
+                {
+                    "file": "communication/comms-overview",
+                    "sections": [
+                        {
+                            "file": "communication/comms-overview/comms-overview-principles",
+                            "title": "Principles of Communicating with Wider Audiences"
+                        }
+                    ],
+                    "title": "Overview of Guide for Communication"
+                }
+            ]
+        }
+    ],
+    "format": "jb-book",
+    "root": "welcome"
 }

--- a/tests/test_files/test_one/_toc.yml
+++ b/tests/test_files/test_one/_toc.yml
@@ -2,11 +2,10 @@
 # Learn more at https://jupyterbook.org/customize/toc.html
 format: jb-book
 root: intro
-parts:
-- chapters:
+chapters:
   - file: setup
     sections:
-    - title: Version Control with Git
-      file: version_control/git
-    - title: Open Data (best practice)
-      file: reproducible_research/open-data
+      - title: Version Control with Git
+        file: version_control/git
+      - title: Open Data (best practice)
+        file: reproducible_research/open-data

--- a/tests/test_files/test_one/dsg_toc.yml
+++ b/tests/test_files/test_one/dsg_toc.yml
@@ -2,9 +2,8 @@
 # Learn more at https://jupyterbook.org/customize/toc.html
 format: jb-book
 root: intro
-parts:
-- chapters:
+chapters:
   - file: setup
     sections:
-    - title: Version Control with Git
-      file: version_control/git
+      - title: Version Control with Git
+        file: version_control/git


### PR DESCRIPTION
Removes the expectation that the toc includes a parts section with one item.
For compatibility with https://github.com/the-turing-way/the-turing-way/pull/3757